### PR TITLE
loopd: verify that dest addr is for corrent chain

### DIFF
--- a/loopd/swapclient_server.go
+++ b/loopd/swapclient_server.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg"
+
 	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/loop"
@@ -34,6 +36,17 @@ const (
 	minConfTarget = 2
 )
 
+var (
+	// errIncorrectChain is returned when the format of the
+	// destination address provided does not match the active chain.
+	errIncorrectChain = errors.New("invalid address format for the " +
+		"active chain")
+
+	// errConfTargetTooLow is returned when the chosen confirmation target
+	// is below the allowed minimum.
+	errConfTargetTooLow = errors.New("confirmation target too low")
+)
+
 // swapClientServer implements the grpc service exposed by loopd.
 type swapClientServer struct {
 	network          lndclient.Network
@@ -58,13 +71,6 @@ func (s *swapClientServer) LoopOut(ctx context.Context,
 
 	log.Infof("Loop out request received")
 
-	sweepConfTarget, err := validateConfTarget(
-		in.SweepConfTarget, loop.DefaultSweepConfTarget,
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	var sweepAddr btcutil.Address
 	if in.Dest == "" {
 		// Generate sweep address if none specified.
@@ -83,8 +89,9 @@ func (s *swapClientServer) LoopOut(ctx context.Context,
 		}
 	}
 
-	// Check that the label is valid.
-	if err := labels.Validate(in.Label); err != nil {
+	sweepConfTarget, err := validateLoopOutRequest(s.lnd.ChainParams,
+		in.SweepConfTarget, sweepAddr, in.Label)
+	if err != nil {
 		return nil, err
 	}
 
@@ -894,8 +901,9 @@ func validateConfTarget(target, defaultTarget int32) (int32, error) {
 
 	// Ensure the target respects our minimum threshold.
 	case target < minConfTarget:
-		return 0, fmt.Errorf("a confirmation target of at least %v "+
+		log.Errorf("a confirmation target of at least %v "+
 			"must be provided", minConfTarget)
+		return 0, errConfTargetTooLow
 
 	default:
 		return target, nil
@@ -919,4 +927,25 @@ func validateLoopInRequest(htlcConfTarget int32, external bool) (int32, error) {
 	}
 
 	return validateConfTarget(htlcConfTarget, loop.DefaultHtlcConfTarget)
+}
+
+// validateLoopOutRequest validates the confirmation target, destination
+// address and label of the loop out request.
+func validateLoopOutRequest(chainParams *chaincfg.Params, confTarget int32,
+	sweepAddr btcutil.Address, label string) (int32, error) {
+
+	// Check that the provided destination address has the correct format
+	// for the active network.
+	if !sweepAddr.IsForNet(chainParams) {
+		log.Errorf("destination address format does not match "+
+			"the active network: %s", chainParams.Name)
+		return 0, errIncorrectChain
+	}
+
+	// Check that the label is valid.
+	if err := labels.Validate(label); err != nil {
+		return 0, err
+	}
+
+	return validateConfTarget(confTarget, loop.DefaultSweepConfTarget)
 }

--- a/loopd/swapclient_server_test.go
+++ b/loopd/swapclient_server_test.go
@@ -1,9 +1,25 @@
 package loopd
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/loop/labels"
+	"github.com/stretchr/testify/require"
+
 	"github.com/lightninglabs/loop"
+)
+
+var (
+	testnetAddr, _ = btcutil.NewAddressScriptHash(
+		[]byte{123}, &chaincfg.TestNet3Params,
+	)
+
+	mainnetAddr, _ = btcutil.NewAddressScriptHash(
+		[]byte{123}, &chaincfg.MainNetParams,
+	)
 )
 
 // TestValidateConfTarget tests all failure and success cases for our conf
@@ -140,6 +156,94 @@ func TestValidateLoopInRequest(t *testing.T) {
 				t.Fatalf("expected: %v, got: %v",
 					test.expectedTarget, conf)
 			}
+		})
+	}
+}
+
+// TestValidateLoopOutRequest tests validation of loop out requests.
+func TestValidateLoopOutRequest(t *testing.T) {
+	tests := []struct {
+		name           string
+		chain          chaincfg.Params
+		confTarget     int32
+		destAddr       btcutil.Address
+		label          string
+		err            error
+		expectedTarget int32
+	}{
+		{
+			name:           "mainnet address with mainnet backend",
+			chain:          chaincfg.MainNetParams,
+			destAddr:       mainnetAddr,
+			label:          "label ok",
+			confTarget:     2,
+			err:            nil,
+			expectedTarget: 2,
+		},
+		{
+			name:           "mainnet address with testnet backend",
+			chain:          chaincfg.TestNet3Params,
+			destAddr:       mainnetAddr,
+			label:          "label ok",
+			confTarget:     2,
+			err:            errIncorrectChain,
+			expectedTarget: 0,
+		},
+		{
+			name:           "testnet address with testnet backend",
+			chain:          chaincfg.TestNet3Params,
+			destAddr:       testnetAddr,
+			label:          "label ok",
+			confTarget:     2,
+			err:            nil,
+			expectedTarget: 2,
+		},
+		{
+			name:           "testnet address with mainnet backend",
+			chain:          chaincfg.MainNetParams,
+			destAddr:       testnetAddr,
+			label:          "label ok",
+			confTarget:     2,
+			err:            errIncorrectChain,
+			expectedTarget: 0,
+		},
+		{
+			name:           "invalid label",
+			chain:          chaincfg.MainNetParams,
+			destAddr:       mainnetAddr,
+			label:          labels.Reserved,
+			confTarget:     2,
+			err:            labels.ErrReservedPrefix,
+			expectedTarget: 0,
+		},
+		{
+			name:           "invalid conf target",
+			chain:          chaincfg.MainNetParams,
+			destAddr:       mainnetAddr,
+			label:          "label ok",
+			confTarget:     1,
+			err:            errConfTargetTooLow,
+			expectedTarget: 0,
+		},
+		{
+			name:           "default conf target",
+			chain:          chaincfg.MainNetParams,
+			destAddr:       mainnetAddr,
+			label:          "label ok",
+			confTarget:     0,
+			err:            nil,
+			expectedTarget: 9,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		
+		t.Run(test.name, func(t *testing.T) {
+			conf, err := validateLoopOutRequest(&test.chain,
+				test.confTarget, test.destAddr, test.label)
+			errors.Is(err, test.err)
+			require.Equal(t, test.expectedTarget, conf)
 		})
 	}
 }


### PR DESCRIPTION
This commit adds verification to the loop out request to ensure that the
formating of the specified destination address matches the network that
lnd is running on.

