### PR TITLE
loopd: validate loop out amount

### DIFF
--- a/loopd/swapclient_server_test.go
+++ b/loopd/swapclient_server_test.go
@@ -1,13 +1,19 @@
 package loopd
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil"
+	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/loop"
 	"github.com/lightninglabs/loop/labels"
+	"github.com/lightninglabs/loop/looprpc"
+	mock_lnd "github.com/lightninglabs/loop/test"
+	"github.com/lightningnetwork/lnd/lnwire"
+	"github.com/lightningnetwork/lnd/routing/route"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,6 +25,40 @@ var (
 	mainnetAddr, _ = btcutil.NewAddressScriptHash(
 		[]byte{123}, &chaincfg.MainNetParams,
 	)
+
+	chanID1 = lnwire.NewShortChanIDFromInt(1)
+	chanID2 = lnwire.NewShortChanIDFromInt(2)
+	chanID3 = lnwire.NewShortChanIDFromInt(3)
+
+	peer1 = route.Vertex{1}
+	peer2 = route.Vertex{2}
+
+	channel1 = lndclient.ChannelInfo{
+		Active:        false,
+		ChannelID:     chanID1.ToUint64(),
+		PubKeyBytes:   peer1,
+		LocalBalance:  10000,
+		RemoteBalance: 0,
+		Capacity:      10000,
+	}
+
+	channel2 = lndclient.ChannelInfo{
+		Active:        true,
+		ChannelID:     chanID2.ToUint64(),
+		PubKeyBytes:   peer2,
+		LocalBalance:  10000,
+		RemoteBalance: 0,
+		Capacity:      10000,
+	}
+
+	channel3 = lndclient.ChannelInfo{
+		Active:        true,
+		ChannelID:     chanID3.ToUint64(),
+		PubKeyBytes:   peer2,
+		LocalBalance:  10000,
+		RemoteBalance: 0,
+		Capacity:      10000,
+	}
 )
 
 // TestValidateConfTarget tests all failure and success cases for our conf
@@ -162,13 +202,17 @@ func TestValidateLoopInRequest(t *testing.T) {
 // TestValidateLoopOutRequest tests validation of loop out requests.
 func TestValidateLoopOutRequest(t *testing.T) {
 	tests := []struct {
-		name           string
-		chain          chaincfg.Params
-		confTarget     int32
-		destAddr       btcutil.Address
-		label          string
-		err            error
-		expectedTarget int32
+		name            string
+		chain           chaincfg.Params
+		confTarget      int32
+		destAddr        btcutil.Address
+		label           string
+		channels        []lndclient.ChannelInfo
+		outgoingChanSet []uint64
+		amount          int64
+		maxRoutingFee   int64
+		err             error
+		expectedTarget  int32
 	}{
 		{
 			name:           "mainnet address with mainnet backend",
@@ -233,6 +277,97 @@ func TestValidateLoopOutRequest(t *testing.T) {
 			err:            nil,
 			expectedTarget: 9,
 		},
+		{
+			name:       "valid amount for default channel set",
+			chain:      chaincfg.MainNetParams,
+			destAddr:   mainnetAddr,
+			label:      "label ok",
+			confTarget: 2,
+			channels: []lndclient.ChannelInfo{
+				channel1, channel2, channel3,
+			},
+			amount:         20000,
+			err:            nil,
+			expectedTarget: 2,
+		},
+		{
+			name: "invalid amount for default channel " +
+				"set",
+			chain:      chaincfg.MainNetParams,
+			destAddr:   mainnetAddr,
+			label:      "label ok",
+			confTarget: 2,
+			channels: []lndclient.ChannelInfo{
+				channel1, channel2, channel3,
+			},
+			amount:         25000,
+			err:            errBalanceTooLow,
+			expectedTarget: 0,
+		},
+		{
+			name: "inactive channel in outgoing channel " +
+				"set",
+			chain:      chaincfg.MainNetParams,
+			destAddr:   mainnetAddr,
+			label:      "label ok",
+			confTarget: 2,
+			channels: []lndclient.ChannelInfo{
+				channel1, channel2, channel3,
+			},
+			outgoingChanSet: []uint64{
+				chanID1.ToUint64(),
+			},
+			amount:         1000,
+			err:            errBalanceTooLow,
+			expectedTarget: 0,
+		},
+		{
+			name:       "outgoing channel set balance is enough",
+			chain:      chaincfg.MainNetParams,
+			destAddr:   mainnetAddr,
+			label:      "label ok",
+			confTarget: 2,
+			channels: []lndclient.ChannelInfo{
+				channel1, channel2, channel3,
+			},
+			outgoingChanSet: []uint64{
+				chanID2.ToUint64(),
+			},
+			amount:         1000,
+			err:            nil,
+			expectedTarget: 2,
+		},
+		{
+			name: "outgoing channel set balance not " +
+				"sufficient",
+			chain:      chaincfg.MainNetParams,
+			destAddr:   mainnetAddr,
+			label:      "label ok",
+			confTarget: 2,
+			channels: []lndclient.ChannelInfo{
+				channel1, channel2, channel3,
+			},
+			outgoingChanSet: []uint64{
+				chanID2.ToUint64(),
+			},
+			amount:         20000,
+			err:            errBalanceTooLow,
+			expectedTarget: 0,
+		},
+		{
+			name:       "amount with routing fee too high",
+			chain:      chaincfg.MainNetParams,
+			destAddr:   mainnetAddr,
+			label:      "label ok",
+			confTarget: 2,
+			channels: []lndclient.ChannelInfo{
+				channel2,
+			},
+			amount:         10000,
+			maxRoutingFee:  100,
+			err:            errBalanceTooLow,
+			expectedTarget: 0,
+		},
 	}
 
 	for _, test := range tests {
@@ -240,10 +375,22 @@ func TestValidateLoopOutRequest(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+			ctx := context.Background()
+
+			lnd := mock_lnd.NewMockLnd()
+			lnd.Channels = test.channels
+
+			req := &looprpc.LoopOutRequest{
+				Amt:               test.amount,
+				MaxSwapRoutingFee: test.maxRoutingFee,
+				OutgoingChanSet:   test.outgoingChanSet,
+				Label:             test.label,
+				SweepConfTarget:   test.confTarget,
+			}
 
 			conf, err := validateLoopOutRequest(
-				&test.chain, test.confTarget, test.destAddr,
-				test.label,
+				ctx, lnd.Client, &test.chain, req,
+				test.destAddr,
 			)
 			require.True(t, errors.Is(err, test.err))
 			require.Equal(t, test.expectedTarget, conf)


### PR DESCRIPTION
This commit adds validation that checks if the loop out amount specified can
be satisfied given the nodes current channel balances.
